### PR TITLE
#6 - Update plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,13 +32,14 @@
     <url>https://github.com/dkpro/dkpro-build-resources</url>
     <tag>HEAD</tag>
   </scm>
-
+  
   <developers>
     <developer>
       <organization>DKPro Team</organization>
       <organizationUrl>https://dkpro.github.io</organizationUrl>
     </developer>
   </developers>
+
   <licenses>
     <license>
       <name>Apache License Version 2.0</name>
@@ -46,6 +47,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>
@@ -56,6 +58,7 @@
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
+
   <issueManagement>
     <system>GitHub Issues</system>
     <url>https://github.com/dkpro/dkpro-build-resources/issues</url>
@@ -70,7 +73,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-remote-resources-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <goals>
@@ -79,13 +82,57 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.4.1</version>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[17,)</version>
+                </requireJavaVersion>
+                <requireMavenVersion>
+                  <version>[3.8.5,)</version>
+                  <message>Minimum Maven version 3.5 required for plugins.</message>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.1.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>3.2.4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.6.3</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.3.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>3.0.1</version>
           <configuration>
             <useReleaseProfile>false</useReleaseProfile>
             <arguments>${arguments} -Pdkpro-release</arguments>


### PR DESCRIPTION
**What's in the PR**
- maven-remote-resources-plugin 1.7.0 -> 3.2.0
- maven-enforcer-plugin -> 3.4.1
- maven-deploy-plugin -> 3.1.2
- maven-gpg-plugin -> 3.2.4
- maven-javadoc-plugin -> 3.6.3
- maven-source-plugin -> 3.3.1
- maven-release-plugin 2.5.3 -> 3.0.1
- Java -> 17
- Maven -> 3.8.5

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
